### PR TITLE
fix: deco switch gas without ascent if within mod of next deco gas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "dive-deco"
-version = "1.3.2"
+version = "1.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dive-deco"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2021"
 license = "MIT"
 description = "A dive decompression models library (Buehlmann ZH-L 16C)"


### PR DESCRIPTION
switch gas without ascent if within mod of next deco gas